### PR TITLE
[FEATURE] make the initializer to expose container part of the test-helpers addon

### DIFF
--- a/test-support/helpers/lookup.js
+++ b/test-support/helpers/lookup.js
@@ -1,3 +1,12 @@
+import Application from '../../app';
+
+Application.initializer({
+    name: 'ember-cli-test-helpers-extract-container',
+    initialize: function(c) {
+        window.__container__ = c;
+    }
+});
+
 var lookup = function(name) {
     var container = window.__container__;
     return container.lookup(name);


### PR DESCRIPTION
This will eliminate the need for every host app to setup this initializer.