### PR TITLE
[FEATURE] support 1.X version of fauxjax API

### DIFF
--- a/test-support/helpers/stub.js
+++ b/test-support/helpers/stub.js
@@ -2,14 +2,16 @@ import Ember from "ember";
 
 var stubEndpointForHttpRequest = function(url, json, verb, status, post_data) {
     return Ember.$.fauxjax.new({
-        type: verb || "GET",
-        url: url,
-        status: status || 200,
-        dataType: "json",
-        contentType: "application/json",
-        responseText: json,
-        data: post_data,
-        cache: false
+        request: {
+            url: url,
+            method: verb || "GET",
+            data: post_data,
+            cache: false
+        },
+        response: {
+            status: status || 200,
+            content: json
+        }
     });
 };
 


### PR DESCRIPTION
This is an initial stab at upgrading the stub helper for the 1.X versions of fauxjax. I need to test this out in a real app but wanted to just get a PR up to make sure I'm on the correct path.