### PR TITLE
[DEPENDENCY] ember-cli 0.2.0 -> 0.2.7

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 bower_components/
 tests/
+tmp/
+dist/
 
 .bowerrc
 .editorconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,19 @@ cache:
   directories:
     - node_modules
 
+env:
+  - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-canary
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-canary
+
 before_install:
+  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 
@@ -20,4 +32,4 @@ install:
   - bower install
 
 script:
-  - npm test
+  - ember try $EMBER_TRY_SCENARIO test

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -2,21 +2,15 @@
 /* global require, module */
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
-
 var app = new EmberAddon();
 
-// Use `app.import` to add additional libraries to the generated
-// output files.
-//
-// If you need to use different assets in different
-// environments, specify an object as the first parameter. That
-// object's keys should be the environment name and the values
-// should be the asset to use in that environment.
-//
-// If the library that you are including contains AMD or ES6
-// modules that you would like to import into your application
-// please specify an object with the list of modules as keys
-// along with the exports of each module as its value.
+/*
+  This Brocfile specifes the options for the dummy test app of this
+  addon, located in `/tests/dummy`
+
+  This Brocfile does *not* influence how the addon or the app using it
+  behave. You most likely want to be modifying `./index.js` or app's Brocfile
+*/
 
 app.import('bower_components/foundation/js/foundation.min.js');
 app.import('bower_components/fauxjax/dist/fauxjax.min.js');

--- a/bower.json
+++ b/bower.json
@@ -1,18 +1,18 @@
 {
   "name": "ember-cli-test-helpers",
   "dependencies": {
-    "jquery": "2.1.1",
-    "ember": "1.12.1",
+    "ember": "1.13.0",
     "ember-resolver": "~0.1.12",
-    "foundation": "zurb/bower-foundation#~5.5.0",
-    "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.2.8",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
+    "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
-    "qunit": "~1.17.1",
-    "fauxjax": "0.5.0",
-    "es5-shim": "^4.0.5"
+    "es5-shim": "^4.0.5",
+    "fauxjax": "1.0.4",
+    "foundation": "zurb/bower-foundation#~5.5.0",
+    "jquery": "2.1.1",
+    "loader.js": "ember-cli/loader.js#3.2.0",
+    "qunit": "~1.17.1"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,35 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'default',
+      dependencies: { }
+    },
+    {
+      name: 'ember-release',
+      dependencies: {
+        'ember': 'components/ember#release'
+      },
+      resolutions: {
+        'ember': 'release'
+      }
+    },
+    {
+      name: 'ember-beta',
+      dependencies: {
+        'ember': 'components/ember#beta'
+      },
+      resolutions: {
+        'ember': 'beta'
+      }
+    },
+    {
+      name: 'ember-canary',
+      dependencies: {
+        'ember': 'components/ember#canary'
+      },
+      resolutions: {
+        'ember': 'canary'
+      }
+    }
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -23,28 +23,32 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.0.0",
-    "ember-cli": "0.2.0",
-    "ember-cli-app-version": "0.3.2",
-    "ember-cli-babel": "^4.0.0",
-    "ember-cli-app-version": "0.3.1",
-    "ember-cli-content-security-policy": "0.3.0",
-    "ember-cli-dependency-checker": "0.0.8",
-    "ember-cli-htmlbars": "0.7.4",
+    "broccoli-asset-rev": "^2.0.2",
+    "ember-cli": "0.2.7",
+    "ember-cli-app-version": "0.3.3",
+    "ember-cli-content-security-policy": "0.4.0",
+    "ember-cli-dependency-checker": "^1.0.0",
+    "ember-cli-htmlbars": "0.7.6",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.9",
-    "ember-cli-uglify": "1.0.1",
+    "ember-cli-qunit": "0.3.13",
+    "ember-cli-uglify": "^1.0.1",
+    "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
+    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-cli-foundation-modal": "~0.2.1",
+    "ember-try": "0.0.6",
     "express": "4.8.5",
     "glob": "4.0.5",
     "phantomjs": "1.9.13",
-    "bower": "1.3.12",
+    "bower": "1.4.1",
     "ember-cli-es5-shim": "~0.1.0"
   },
   "keywords": [
     "ember-addon"
   ],
+  "dependencies": {
+    "ember-cli-babel": "^5.0.0"
+  },
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }

--- a/test-support/helpers/input.js
+++ b/test-support/helpers/input.js
@@ -39,7 +39,7 @@ var isCheckbox = function(selector) {
 };
 
 var isHiddenInput = function(name, value) {
-    var element = assertElement("input[name=%@]".fmt(name), "hidden");
+    var element = assertElement("input[name=" + name + "]", "hidden");
     QUnit.assert.equal(element.val(), value, "value of '" + value + "' is not equal to the element's value of '" + element.val() + "'");
 };
 
@@ -122,7 +122,7 @@ var selectRadioButton = function(selector, value) {
                 }
             });
         } else {
-            find(selector).filter("[value=%@]".fmt(value)).prop("checked", true).trigger("change");
+            find(selector).filter("[value=" + value + "]").prop("checked", true).trigger("change");
         }
     });
 };

--- a/testem.json
+++ b/testem.json
@@ -1,6 +1,7 @@
 {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
+  "disable_watching": true,
   "launch_in_ci": [
     "PhantomJS"
   ],

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,9 +3,11 @@ import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
+var App;
+
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-var App = Ember.Application.extend({
+App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver: Resolver

--- a/tests/dummy/public/crossdomain.xml
+++ b/tests/dummy/public/crossdomain.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
-    <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
+  <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
 
-    <!-- Most restrictive policy: -->
-    <site-control permitted-cross-domain-policies="none"/>
+  <!-- Most restrictive policy: -->
+  <site-control permitted-cross-domain-policies="none"/>
 
-    <!-- Least restrictive policy: -->
-    <!--
-    <site-control permitted-cross-domain-policies="all"/>
-    <allow-access-from domain="*" to-ports="*" secure="false"/>
-    <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
-    -->
+  <!-- Least restrictive policy: -->
+  <!--
+  <site-control permitted-cross-domain-policies="all"/>
+  <allow-access-from domain="*" to-ports="*" secure="false"/>
+  <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
+  -->
 </cross-domain-policy>

--- a/tests/dummy/public/robots.txt
+++ b/tests/dummy/public/robots.txt
@@ -1,2 +1,3 @@
 # http://www.robotstxt.org
 User-agent: *
+Disallow:


### PR DESCRIPTION
When I set out to do this upgrade, I had the intention of fixing the computed property get/set issue in the `test-done` helper. Apparently I had missed the commit that fixed this issue, but I went ahead with the upgrade and fixed another prototype extension.