### PR TITLE
[ENHANCEMENT] updating API to be more extensible and easier to remember

### DIFF
--- a/test-support/helpers/stub.js
+++ b/test-support/helpers/stub.js
@@ -43,12 +43,8 @@ var stubEndpointForHttpRequest = function(url, json, verb, status, post_data) {
     });
 };
 
-var clearRequests = function(id) {
-    if (id) {
-        Ember.$.fauxjax.remove(id);
-    } else {
-        Ember.$.fauxjax.clear();
-    }
+var clearStubRequests = function(id) {
+    clearStubHttpRequests(id);
 };
 
 var clearStubHttpRequests = function(id) {
@@ -59,4 +55,4 @@ var clearStubHttpRequests = function(id) {
     }
 };
 
-export { stubEndpointForHttpRequest, clearStubHttpRequests, stubRequest, clearRequests };
+export { stubEndpointForHttpRequest, clearStubHttpRequests, stubRequest, clearStubRequests };

--- a/test-support/helpers/stub.js
+++ b/test-support/helpers/stub.js
@@ -1,5 +1,20 @@
 import Ember from "ember";
 
+var stubRequest = function(request, response) {
+    return Ember.$.fauxjax.new({
+        request: {
+            url: request.url,
+            data: request.data,
+            method: request.method || "GET",
+            cache: false
+        },
+        response: {
+            status: response.status || 200,
+            content: response.json
+        }
+    });
+};
+
 var stubEndpointForHttpRequest = function(url, json, verb, status, post_data) {
     return Ember.$.fauxjax.new({
         request: {
@@ -15,6 +30,14 @@ var stubEndpointForHttpRequest = function(url, json, verb, status, post_data) {
     });
 };
 
+var clearRequests = function(id) {
+    if (id) {
+        Ember.$.fauxjax.remove(id);
+    } else {
+        Ember.$.fauxjax.clear();
+    }
+};
+
 var clearStubHttpRequests = function(id) {
     if (id) {
         Ember.$.fauxjax.remove(id);
@@ -23,4 +46,4 @@ var clearStubHttpRequests = function(id) {
     }
 };
 
-export { stubEndpointForHttpRequest, clearStubHttpRequests };
+export { stubEndpointForHttpRequest, clearStubHttpRequests, stubRequest, clearRequests };

--- a/test-support/helpers/stub.js
+++ b/test-support/helpers/stub.js
@@ -1,17 +1,30 @@
 import Ember from "ember";
 
-var stubRequest = function(request, response) {
+var setupRequest = function setupRequest(request) {
     request = request || {};
-    response = response || {};
+    // request must have url set
     if(!request.url) {
         throw Error("Please provide a url for the request");
     }
+    // set some reasonable defaults that can be overridden
     request.cache = request.cache || false;
     request.method = request.method || "GET";
+    return request;
+};
+
+var setupResponse = function setupResponse(response) {
+    response = response || {};
+    // set some reasonable defaults that can be overridden
     response.status = response.status || 200;
+    return response;
+};
+
+var stubRequest = function(request, response) {
+    var fauxRequest = setupRequest(request);
+    var fauxResponse = setupResponse(response);
     return Ember.$.fauxjax.new({
-        request: request,
-        response: response
+        request: fauxRequest,
+        response: fauxResponse
     });
 };
 

--- a/test-support/helpers/stub.js
+++ b/test-support/helpers/stub.js
@@ -1,17 +1,17 @@
 import Ember from "ember";
 
 var stubRequest = function(request, response) {
+    request = request || {};
+    response = response || {};
+    if(!request.url) {
+        throw Error("Please provide a url for the request");
+    }
+    request.cache = request.cache || false;
+    request.method = request.method || "GET";
+    response.status = response.status || 200;
     return Ember.$.fauxjax.new({
-        request: {
-            url: request.url,
-            data: request.data,
-            method: request.method || "GET",
-            cache: false
-        },
-        response: {
-            status: response.status || 200,
-            content: response.json
-        }
+        request: request,
+        response: response
     });
 };
 

--- a/tests/acceptance/stub-test.js
+++ b/tests/acceptance/stub-test.js
@@ -1,0 +1,32 @@
+import { test } from "qunit";
+import QUnit from "qunit";
+import module from "../helpers/module";
+import {stubRequest} from "../helpers/stub";
+
+var originalOk, okCounter;
+
+module("Acceptance: Stub Tests", {
+    beforeEach: function() {
+        okCounter = 0;
+        originalOk = QUnit.assert.ok;
+        QUnit.assert.ok = function() { okCounter += 1; };
+    },
+    afterEach: function(assert) {
+        QUnit.assert.ok = originalOk;
+        // This is asserting all stubs for requests are properly handled
+        assert.equal(okCounter, 0);
+    }
+});
+
+test('module will not fail if stub does not specify response.content', function(assert) {
+    stubRequest({url: "/wat", method: "POST"});
+    $.ajax({
+        method: "POST",
+        url: "/wat"
+    });
+    stubRequest({url: "/foo"});
+    $.ajax({
+        method: "GET",
+        url: "/foo"
+    });
+});

--- a/tests/unit/stub-test.js
+++ b/tests/unit/stub-test.js
@@ -1,0 +1,32 @@
+import { test } from "qunit";
+import QUnit from "qunit";
+import module from "../helpers/module";
+import {stubRequest} from "../helpers/stub";
+
+var originalOk, okCounter;
+
+module("Unit: Stub Tests", {
+    beforeEach: function() {
+        okCounter = 0;
+        originalOk = QUnit.assert.ok;
+        QUnit.assert.ok = function() { okCounter += 1; };
+    },
+    afterEach: function(assert) {
+        QUnit.assert.ok = originalOk;
+        // This is asserting all stubs for requests are properly handled
+        assert.equal(okCounter, 0);
+    }
+});
+
+test('module will not fail if stub does not specify response.content', function(assert) {
+    stubRequest({url: "/wat", method: "POST"});
+    $.ajax({
+        method: "POST",
+        url: "/wat"
+    });
+    stubRequest({url: "/foo"});
+    $.ajax({
+        method: "GET",
+        url: "/foo"
+    });
+});

--- a/tests/unit/stub-test.js
+++ b/tests/unit/stub-test.js
@@ -1,32 +1,54 @@
-import { test } from "qunit";
-import QUnit from "qunit";
-import module from "../helpers/module";
+import Ember from "ember";
+import { test, module } from "qunit";
 import {stubRequest} from "../helpers/stub";
 
-var originalOk, okCounter;
 
 module("Unit: Stub Tests", {
-    beforeEach: function() {
-        okCounter = 0;
-        originalOk = QUnit.assert.ok;
-        QUnit.assert.ok = function() { okCounter += 1; };
-    },
-    afterEach: function(assert) {
-        QUnit.assert.ok = originalOk;
-        // This is asserting all stubs for requests are properly handled
-        assert.equal(okCounter, 0);
+    afterEach: function() {
+        Ember.$.fauxjax.clear();
     }
 });
 
-test('module will not fail if stub does not specify response.content', function(assert) {
+test("stubRequest requires a request.url", function(assert) {
+    try {
+        stubRequest({});
+    } catch(e) {
+        assert.equal(e.message, "Please provide a url for the request");
+    }
+});
+
+test("stubRequest will set request.cache to false by default", function(assert) {
+    stubRequest({url: "/wat", method: "GET"});
+    var stub = Ember.$.fauxjax.unfired()[0];
+    assert.equal(false, stub.request.cache);
+});
+
+test("stubRequest will respect request.cache if set", function(assert) {
+    stubRequest({url: "/wat", method: "GET", cache: true});
+    var stub = Ember.$.fauxjax.unfired()[0];
+    assert.equal(true, stub.request.cache);
+});
+
+test("stubRequest will set request.method to 'GET' by default", function(assert) {
+    stubRequest({url: "/wat"});
+    var stub = Ember.$.fauxjax.unfired()[0];
+    assert.equal("GET", stub.request.method);
+});
+
+test("stubRequest will respect request.method if set", function(assert) {
     stubRequest({url: "/wat", method: "POST"});
-    $.ajax({
-        method: "POST",
-        url: "/wat"
-    });
-    stubRequest({url: "/foo"});
-    $.ajax({
-        method: "GET",
-        url: "/foo"
-    });
+    var stub = Ember.$.fauxjax.unfired()[0];
+    assert.equal("POST", stub.request.method);
+});
+
+test("stubRequest will set response.status to 200 by default", function(assert) {
+    stubRequest({url: "/wat"});
+    var stub = Ember.$.fauxjax.unfired()[0];
+    assert.equal(200, stub.response.status);
+});
+
+test("stubRequest will respect response.status if set", function(assert) {
+    stubRequest({url: "/wat", method: "POST"}, {status: 201});
+    var stub = Ember.$.fauxjax.unfired()[0];
+    assert.equal(201, stub.response.status);
 });


### PR DESCRIPTION
I am updating the API for the stub and clear methods as I have trouble remembering (a) the name of the import and (b) the name/number/order of parameters to the stub function. I think the names could be shorter and easier to remember. I also think that taking a request and response allows this stub to be more flexible and take advantage of new fauxjax features without also changing it's API to accomodate.